### PR TITLE
add a fallback option for authorization in headers if it starts with …

### DIFF
--- a/api/middlewares/authJwt.js
+++ b/api/middlewares/authJwt.js
@@ -5,7 +5,7 @@ var User = require("../models/user");
 
 verifyToken = (req, res, next) => { 
 // console.log(req.headers);
-    let token = req.headers["authorization"];
+    let token = req.headers["authorization"] || req.headers["Authorization"];
     if(!token) {
         return res.status(403).send({message: "No token provided!"});
     }


### PR DESCRIPTION
…captial A.

The authorization key in req.headers sometimes could be Authorization. This commit will make the auhtJwt middleware handle that.