### PR TITLE
refactor: timestamps & string trim in schema

### DIFF
--- a/api/models/port.js
+++ b/api/models/port.js
@@ -1,12 +1,15 @@
 var mongoose = require("mongoose");
 
+// trim every string fields of complete document
+mongoose.Schema.Types.String.set("trim", true);
 
 var PortSchema = new mongoose.Schema({
     lastPort:{
         type:Number,
-        trim: true,
         // required:true,
     },
 });
+
+PortSchema.set("timestamps", true);
 
 module.exports = mongoose.model("Ports",PortSchema);

--- a/api/models/user.js
+++ b/api/models/user.js
@@ -1,6 +1,9 @@
 var mongoose = require("mongoose");
 var bcrypt = require("bcrypt");
 
+// trim every string fields of complete document
+mongoose.Schema.Types.String.set("trim", true);
+
 var UserSchema = new mongoose.Schema({
     // user_name: {
     //     type: String,
@@ -14,7 +17,6 @@ var UserSchema = new mongoose.Schema({
     port:{
         type:String,
         unique:true,
-        trim: true,
         // required:true,
     },
     occupied:{
@@ -26,7 +28,6 @@ var UserSchema = new mongoose.Schema({
         type: String,
         unique: true,
         lowercase: true,
-        trim: true,
         required: true,
     },
     // password: {
@@ -52,6 +53,10 @@ var UserSchema = new mongoose.Schema({
     
 
 });
+
+// It will create createdAt and updatedAt field automatically and 
+// also update their values on every time on performing create and update operation
+UserSchema.set("timestamps", true);
 
 // UserSchema.methods.comparePassword = function(password) {
 //     return bcrypt.compareSync(password, this.password);


### PR DESCRIPTION
Hi there,
Please find below the changes in this PR:
1. set "timestamps" to true [can access **createdAt** and **updatedAt** fields as these are generated by MongoDB automatically].
2. set string trim to true [ trim documents string fields while saving and updating".